### PR TITLE
Implement contact storage

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -191,6 +191,7 @@ class Order(Base):
     amount = Column(Integer, nullable=False)  # 금액
     kakao_tid = Column(String(100), unique=True, nullable=False)  # 카카오 결제 ID
     pdf_send_email = Column(String(100), nullable=True)  # PDF 리포트 발송 이메일
+    pdf_send_phone = Column(String(50), nullable=True)  # PDF 발송용 전화번호
     status = Column(Enum("pending", "paid", "refunded", "cancelled"), default="pending")  # 주문 상태 (예: pending, completed, cancelled)
     analysis_cache_id = Column(Integer, ForeignKey("saju_analysis_cache.id"), nullable=True)  # 사주 분석 캐시 ID
     created_at = Column(DateTime, default=datetime.utcnow)

--- a/templates/saju/page2.html
+++ b/templates/saju/page2.html
@@ -393,6 +393,24 @@ async function startPremiumPurchase() {
   location.href = next_redirect_pc_url;
 }
 
+async function saveUserContact() {
+  const email = document.getElementById('emailInput').value;
+  const phone = document.getElementById('phoneInput').value;
+
+  try {
+    await fetch('/order/save-contact', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ email, phone })
+    });
+    document.getElementById('infoModal').classList.add('hidden');
+    startPremiumPurchase();
+  } catch (err) {
+    console.error('contact save error', err);
+    alert('연락처 저장에 실패했습니다.');
+  }
+}
+
 // 후원 모달 관련
 function showDonationModal() {
   document.getElementById('donationModal').style.display = 'block';


### PR DESCRIPTION
## Summary
- capture phone numbers for premium orders
- save contact info via `/order/save-contact` API
- allow page2 HTML to send phone and email using `saveUserContact()`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685496eed250832b813b110afa0a9dbc