### PR TITLE
Add custom exception handling

### DIFF
--- a/app/dependencies.py
+++ b/app/dependencies.py
@@ -1,5 +1,6 @@
 # app/dependencies.py
-from fastapi import Request, HTTPException, Depends
+from fastapi import Request, Depends
+from app.exceptions import UnauthorizedError
 from sqlalchemy.orm import Session
 from app.database import get_db
 from app.models import User
@@ -8,11 +9,11 @@ def get_current_user(request: Request, db: Session = Depends(get_db)):
     """현재 로그인된 사용자 반환"""
     user_id = request.session.get('user_id')
     if not user_id:
-        raise HTTPException(status_code=401, detail="로그인이 필요합니다.")
+        raise UnauthorizedError("로그인이 필요합니다.")
     
     user = db.query(User).filter(User.id == user_id).first()
     if not user:
-        raise HTTPException(status_code=401, detail="유효하지 않은 사용자입니다.")
+        raise UnauthorizedError("유효하지 않은 사용자입니다.")
     
     return user
 

--- a/app/exceptions.py
+++ b/app/exceptions.py
@@ -1,0 +1,26 @@
+from fastapi import HTTPException, status
+
+
+class BadRequestError(HTTPException):
+    def __init__(self, detail: str = "잘못된 요청입니다."):
+        super().__init__(status_code=status.HTTP_400_BAD_REQUEST, detail=detail)
+
+
+class UnauthorizedError(HTTPException):
+    def __init__(self, detail: str = "인증이 필요합니다."):
+        super().__init__(status_code=status.HTTP_401_UNAUTHORIZED, detail=detail)
+
+
+class PermissionDeniedError(HTTPException):
+    def __init__(self, detail: str = "권한이 없습니다."):
+        super().__init__(status_code=status.HTTP_403_FORBIDDEN, detail=detail)
+
+
+class NotFoundError(HTTPException):
+    def __init__(self, detail: str = "대상을 찾을 수 없습니다."):
+        super().__init__(status_code=status.HTTP_404_NOT_FOUND, detail=detail)
+
+
+class InternalServerError(HTTPException):
+    def __init__(self, detail: str = "서버 오류가 발생했습니다."):
+        super().__init__(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=detail)

--- a/app/main.py
+++ b/app/main.py
@@ -11,6 +11,7 @@ from app.routers import auth, blog, admin, saju, order  # order 추가 ✓
 from app.utils import get_flashed_messages
 from starlette.exceptions import HTTPException as StarletteHTTPException
 from starlette.status import HTTP_404_NOT_FOUND, HTTP_500_INTERNAL_SERVER_ERROR
+from app.utils.error_handlers import register_exception_handlers
 import os
 
 
@@ -38,6 +39,8 @@ app.include_router(admin.router)
 app.include_router(saju.router)
 app.include_router(order.router)  # 이 라인 추가 ✓
 
+register_exception_handlers(app)
+
 @app.get("/", response_class=HTMLResponse)
 async def home(request: Request, db: Session = Depends(get_db)):
     recent_posts = db.query(Post).filter(
@@ -52,16 +55,6 @@ async def home(request: Request, db: Session = Depends(get_db)):
         "categories": categories
     })
 
-@app.exception_handler(StarletteHTTPException)
-async def custom_http_exception_handler(request: Request, exc: StarletteHTTPException):
-    if exc.status_code == HTTP_404_NOT_FOUND:
-        return templates.TemplateResponse("errors/404.html", {"request": request}, status_code=404)
-    return templates.TemplateResponse("errors/error.html", {"request": request, "code": exc.status_code}, status_code=exc.status_code)
-
-@app.exception_handler(Exception)
-async def custom_exception_handler(request: Request, exc: Exception):
-    print(f"서버 오류: {exc}")  # 디버깅용 로그
-    return templates.TemplateResponse("errors/500.html", {"request": request}, status_code=500)
 
 if __name__ == "__main__":
     import uvicorn

--- a/app/routers/admin.py
+++ b/app/routers/admin.py
@@ -1,4 +1,5 @@
-from fastapi import APIRouter, Request, Form, File, UploadFile, Depends, HTTPException
+from fastapi import APIRouter, Request, Form, File, UploadFile, Depends
+from app.exceptions import NotFoundError, PermissionDeniedError
 from fastapi.responses import HTMLResponse, RedirectResponse
 from sqlalchemy.orm import Session
 from app.database import get_db
@@ -162,7 +163,7 @@ async def admin_edit_post(
 ):
     post = db.query(Post).filter(Post.id == post_id).first()
     if not post:
-        raise HTTPException(status_code=404, detail="포스트를 찾을 수 없습니다.")
+        raise NotFoundError("포스트를 찾을 수 없습니다.")
 
     form = PostForm(obj=post)
     categories = db.query(Category).all()
@@ -195,7 +196,7 @@ async def admin_edit_post_submit(
 ):
     post = db.query(Post).filter(Post.id == post_id).first()
     if not post:
-        raise HTTPException(status_code=404, detail="포스트를 찾을 수 없습니다.")
+        raise NotFoundError("포스트를 찾을 수 없습니다.")
 
     slug = create_slug(title)
     if slug != post.slug:
@@ -363,7 +364,7 @@ async def admin_edit_in_post(
 ):
     item = db.query(InPost).filter(InPost.id == item_id).first()
     if not item:
-        raise HTTPException(status_code=404, detail="항목을 찾을 수 없습니다.")
+        raise NotFoundError("항목을 찾을 수 없습니다.")
     form = InPostForm(obj=item)
     return templates.TemplateResponse(
         "admin/in_posts_form.html",
@@ -385,7 +386,7 @@ async def admin_edit_in_post_submit(
 ):
     item = db.query(InPost).filter(InPost.id == item_id).first()
     if not item:
-        raise HTTPException(status_code=404, detail="항목을 찾을 수 없습니다.")
+        raise NotFoundError("항목을 찾을 수 없습니다.")
     item.title = title
     item.content = content
     item.gen_content1 = gen_content1
@@ -522,7 +523,7 @@ async def admin_edit_saju_user(
 ):
     saju_user = db.query(SajuUser).filter(SajuUser.id == saju_user_id).first()
     if not saju_user:
-        raise HTTPException(status_code=404, detail="사용자를 찾을 수 없습니다.")
+        raise NotFoundError("사용자를 찾을 수 없습니다.")
     form = SajuUserAdminForm(obj=saju_user)
     form.user_id.choices = [(u.id, u.username) for u in db.query(User).all()]
     form.user_id.data = saju_user.user_id
@@ -546,7 +547,7 @@ async def admin_edit_saju_user_submit(
 ):
     saju_user = db.query(SajuUser).filter(SajuUser.id == saju_user_id).first()
     if not saju_user:
-        raise HTTPException(status_code=404, detail="사용자를 찾을 수 없습니다.")
+        raise NotFoundError("사용자를 찾을 수 없습니다.")
     saju_user.name = name
     saju_user.birthdate = birthdate
     saju_user.birthhour = birthhour
@@ -583,7 +584,7 @@ async def admin_edit_filtered(
         db.query(FilteredContent).filter(FilteredContent.id == content_id).first()
     )
     if not content:
-        raise HTTPException(status_code=404, detail="콘텐츠를 찾을 수 없습니다.")
+        raise NotFoundError("콘텐츠를 찾을 수 없습니다.")
     form = FilteredContentForm(obj=content)
     return templates.TemplateResponse(
         "admin/filtered_content_form.html",
@@ -611,7 +612,7 @@ async def admin_edit_filtered_submit(
         db.query(FilteredContent).filter(FilteredContent.id == content_id).first()
     )
     if not content:
-        raise HTTPException(status_code=404, detail="콘텐츠를 찾을 수 없습니다.")
+        raise NotFoundError("콘텐츠를 찾을 수 없습니다.")
     content.filter_result = filter_result
     content.reasoning = reasoning
     content.confidence_score = confidence_score

--- a/app/routers/blog.py
+++ b/app/routers/blog.py
@@ -1,6 +1,7 @@
 # app/routers/blog.py 수정본 - 라우터 순서 중요!
 
-from fastapi import APIRouter, Request, Depends, HTTPException
+from fastapi import APIRouter, Request, Depends
+from app.exceptions import NotFoundError
 from fastapi.responses import HTMLResponse
 from sqlalchemy.orm import Session
 from urllib.parse import unquote
@@ -58,7 +59,7 @@ async def blog_category(
         # 디버깅: 존재하는 카테고리들 출력
         existing_categories = db.query(Category).all()
         print(f"📋 존재하는 카테고리들: {[c.slug for c in existing_categories]}")
-        raise HTTPException(status_code=404, detail="카테고리를 찾을 수 없습니다.")
+        raise NotFoundError("카테고리를 찾을 수 없습니다.")
     
     per_page = 6
     offset = (page - 1) * per_page
@@ -110,7 +111,7 @@ async def blog_detail(
         ).first()
     
     if not post:
-        raise HTTPException(status_code=404, detail="포스트를 찾을 수 없습니다.")
+        raise NotFoundError("포스트를 찾을 수 없습니다.")
     
     # 조회수 증가
     if post.views is None:

--- a/app/routers/saju.py
+++ b/app/routers/saju.py
@@ -1,6 +1,7 @@
 # app/routers/saju.py - 완전한 작동 버전
 
-from fastapi import APIRouter, Request, Form, Depends, HTTPException
+from fastapi import APIRouter, Request, Form, Depends
+from app.exceptions import BadRequestError
 from fastapi.responses import HTMLResponse, RedirectResponse
 from app.database import get_db
 from app.models import Post, Category, SajuUser, SajuAnalysisCache, SajuInterpretation, Product
@@ -760,7 +761,7 @@ async def saju_page1_submit(
 
     # 입력값 검증
     if not gender or not birth_year or not birth_month or not birth_day:
-        raise HTTPException(status_code=400, detail="필수 입력값이 누락되었습니다.")
+        raise BadRequestError("필수 입력값이 누락되었습니다.")
 
     # 출생 시간 처리 (refactored to match latest logic)
     if hour_unknown:
@@ -904,7 +905,7 @@ async def api_saju_ai_analysis(request: Request, db: Session = Depends(get_db)):
     
     saju_key = request.session.get("saju_key")
     if not saju_key:
-        raise HTTPException(status_code=400, detail="사주 정보가 없습니다.")
+        raise BadRequestError("사주 정보가 없습니다.")
     
     # 🔄 글로벌 캐시 확인
     cached_row = db.query(SajuAnalysisCache).filter_by(saju_key=saju_key).first()
@@ -1179,7 +1180,7 @@ async def api_saju_ai_analysis_2(request: Request, db: Session = Depends(get_db)
  # === DB 캐시 확인 ===
     saju_key = request.session.get("saju_key")
     if not saju_key:
-        raise HTTPException(status_code=400, detail="사주 정보가 없습니다.")
+        raise BadRequestError("사주 정보가 없습니다.")
 
 
  # DB 캐시 확인
@@ -1226,7 +1227,7 @@ async def api_saju_ai_analysis_2(request: Request, db: Session = Depends(get_db)
         
     except Exception as e:
         logger.error(f"AI 분석 실패: {e}")
-        raise HTTPException(status_code=400, detail="AI 분석 중 오류가 발생했습니다.")
+        raise BadRequestError("AI 분석 중 오류가 발생했습니다.")
 
 # AI 사주 2차 업그레이드 버전 API 끝
 #######################################################################

--- a/app/utils/error_handlers.py
+++ b/app/utils/error_handlers.py
@@ -1,0 +1,42 @@
+from fastapi import Request, FastAPI
+from fastapi.responses import JSONResponse
+from starlette.exceptions import HTTPException as StarletteHTTPException
+from starlette.status import HTTP_404_NOT_FOUND, HTTP_500_INTERNAL_SERVER_ERROR
+from app.template import templates
+
+
+def prefers_json(request: Request) -> bool:
+    accept = request.headers.get("accept", "").lower()
+    if "application/json" not in accept:
+        return False
+    if "text/html" not in accept:
+        return True
+    return accept.index("application/json") < accept.index("text/html")
+
+
+def register_exception_handlers(app: FastAPI) -> None:
+    @app.exception_handler(StarletteHTTPException)
+    async def http_exception_handler(request: Request, exc: StarletteHTTPException):
+        if prefers_json(request):
+            return JSONResponse({"detail": exc.detail}, status_code=exc.status_code)
+        if exc.status_code == HTTP_404_NOT_FOUND:
+            return templates.TemplateResponse("errors/404.html", {"request": request}, status_code=404)
+        return templates.TemplateResponse(
+            "errors/error.html",
+            {"request": request, "code": exc.status_code},
+            status_code=exc.status_code,
+        )
+
+    @app.exception_handler(Exception)
+    async def generic_exception_handler(request: Request, exc: Exception):
+        print(f"서버 오류: {exc}")
+        if prefers_json(request):
+            return JSONResponse(
+                {"detail": "서버 오류가 발생했습니다."},
+                status_code=HTTP_500_INTERNAL_SERVER_ERROR,
+            )
+        return templates.TemplateResponse(
+            "errors/500.html",
+            {"request": request},
+            status_code=HTTP_500_INTERNAL_SERVER_ERROR,
+        )


### PR DESCRIPTION
## Summary
- define localized custom HTTPException subclasses
- implement exception handler registration
- convert `utils.py` to package and add error handler helpers
- integrate handler registration in app initialization
- use new exceptions across routers and dependencies

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for celery and sqlalchemy)*

------
https://chatgpt.com/codex/tasks/task_e_685f3c1965e8832bb46efde2fa946989