### PR TITLE
Fix JSON error handling for order APIs

### DIFF
--- a/app/routers/order.py
+++ b/app/routers/order.py
@@ -568,8 +568,8 @@ async def view_report(
     try:
         # HTML 파일 읽어서 직접 반환
         import os
-            if not os.path.exists(order.report_html):
-                raise NotFoundError("리포트 파일이 존재하지 않습니다.")
+        if not os.path.exists(order.report_html):
+            raise NotFoundError("리포트 파일이 존재하지 않습니다.")
             
         with open(order.report_html, 'r', encoding='utf-8') as f:
             html_content = f.read()

--- a/app/utils/error_handlers.py
+++ b/app/utils/error_handlers.py
@@ -6,7 +6,15 @@ from app.template import templates
 
 
 def prefers_json(request: Request) -> bool:
+    """Return True if the client expects a JSON response."""
     accept = request.headers.get("accept", "").lower()
+
+    # 1) If the request path looks like an API endpoint (e.g. /order/**),
+    #    return JSON regardless of the Accept header.
+    if request.url.path.startswith("/order"):
+        return True
+
+    # 2) Otherwise determine preference based on the Accept header.
     if "application/json" not in accept:
         return False
     if "text/html" not in accept:

--- a/tests/test_order_api.py
+++ b/tests/test_order_api.py
@@ -1,0 +1,63 @@
+import os
+import types
+import pytest
+from fastapi.testclient import TestClient
+
+# Set dummy API key so importing app doesn't fail
+os.environ.setdefault("OPENAI_API_KEY", "test")
+os.environ.setdefault("DATABASE_URL", "sqlite:///./test.db")
+
+from app.main import app
+from app.dependencies import get_current_user
+from app.database import get_db
+from app.exceptions import UnauthorizedError
+
+
+class DummySession:
+    def query(self, *args, **kwargs):
+        return self
+
+    def filter(self, *args, **kwargs):
+        return self
+
+    def first(self):
+        return None
+
+    def close(self):
+        pass
+
+def override_get_db():
+    db = DummySession()
+    try:
+        yield db
+    finally:
+        db.close()
+
+
+def override_unauthenticated():
+    raise UnauthorizedError("로그인이 필요합니다.")
+
+
+def override_user():
+    return types.SimpleNamespace(id=1)
+
+
+app.dependency_overrides[get_db] = override_get_db
+
+
+def test_order_create_unauthenticated():
+    app.dependency_overrides[get_current_user] = override_unauthenticated
+    client = TestClient(app)
+    res = client.post("/order/create", json={"saju_key": "test"})
+    assert res.status_code == 401
+    assert res.json()["detail"] == "로그인이 필요합니다."
+    app.dependency_overrides.pop(get_current_user)
+
+
+def test_order_status_not_found():
+    app.dependency_overrides[get_current_user] = override_user
+    client = TestClient(app)
+    res = client.get("/order/status/1")
+    assert res.status_code == 404
+    assert res.json()["detail"] == "주문을 찾을 수 없습니다."
+    app.dependency_overrides.pop(get_current_user)


### PR DESCRIPTION
## Summary
- improve `prefers_json` to check `/order` paths
- fix indentation bug in order router
- add tests for JSON error messages on `/order` routes

## Testing
- `pip install fastapi==0.104.1 uvicorn==0.24.0 jinja2==3.1.2 python-multipart==0.0.6 sqlalchemy==2.0.23 pymysql==1.1.0 python-dotenv==1.0.0 wtforms==3.1.0 'python-jose[cryptography]==3.3.0' 'passlib[bcrypt]==1.7.4' aiofiles==23.2.1 pillow==10.1.0 itsdangerous==2.1.2 starlette==0.27.0 pytest==7.4.3 httpx==0.25.2`
- `pip install markdown==3.8.1 matplotlib pandas sxtwl requests openai`
- `pytest -q tests/test_order_api.py`

------
https://chatgpt.com/codex/tasks/task_e_685f3e174294832b985a00860d3a5948