### PR TITLE
Add detailed logging before raising errors

### DIFF
--- a/app/routers/admin.py
+++ b/app/routers/admin.py
@@ -1,5 +1,8 @@
 from fastapi import APIRouter, Request, Form, File, UploadFile, Depends
 from app.exceptions import NotFoundError, PermissionDeniedError
+import logging
+
+logger = logging.getLogger(__name__)
 from fastapi.responses import HTMLResponse, RedirectResponse
 from sqlalchemy.orm import Session
 from app.database import get_db
@@ -163,6 +166,7 @@ async def admin_edit_post(
 ):
     post = db.query(Post).filter(Post.id == post_id).first()
     if not post:
+        logger.warning(f"Post not found: post_id={post_id}")
         raise NotFoundError("포스트를 찾을 수 없습니다.")
 
     form = PostForm(obj=post)
@@ -196,6 +200,7 @@ async def admin_edit_post_submit(
 ):
     post = db.query(Post).filter(Post.id == post_id).first()
     if not post:
+        logger.warning(f"Post not found: post_id={post_id}")
         raise NotFoundError("포스트를 찾을 수 없습니다.")
 
     slug = create_slug(title)
@@ -364,6 +369,7 @@ async def admin_edit_in_post(
 ):
     item = db.query(InPost).filter(InPost.id == item_id).first()
     if not item:
+        logger.warning(f"InPost not found: item_id={item_id}")
         raise NotFoundError("항목을 찾을 수 없습니다.")
     form = InPostForm(obj=item)
     return templates.TemplateResponse(
@@ -386,6 +392,7 @@ async def admin_edit_in_post_submit(
 ):
     item = db.query(InPost).filter(InPost.id == item_id).first()
     if not item:
+        logger.warning(f"InPost not found: item_id={item_id}")
         raise NotFoundError("항목을 찾을 수 없습니다.")
     item.title = title
     item.content = content
@@ -523,6 +530,7 @@ async def admin_edit_saju_user(
 ):
     saju_user = db.query(SajuUser).filter(SajuUser.id == saju_user_id).first()
     if not saju_user:
+        logger.warning(f"SajuUser not found: saju_user_id={saju_user_id}")
         raise NotFoundError("사용자를 찾을 수 없습니다.")
     form = SajuUserAdminForm(obj=saju_user)
     form.user_id.choices = [(u.id, u.username) for u in db.query(User).all()]
@@ -547,6 +555,7 @@ async def admin_edit_saju_user_submit(
 ):
     saju_user = db.query(SajuUser).filter(SajuUser.id == saju_user_id).first()
     if not saju_user:
+        logger.warning(f"SajuUser not found: saju_user_id={saju_user_id}")
         raise NotFoundError("사용자를 찾을 수 없습니다.")
     saju_user.name = name
     saju_user.birthdate = birthdate
@@ -584,6 +593,7 @@ async def admin_edit_filtered(
         db.query(FilteredContent).filter(FilteredContent.id == content_id).first()
     )
     if not content:
+        logger.warning(f"FilteredContent not found: content_id={content_id}")
         raise NotFoundError("콘텐츠를 찾을 수 없습니다.")
     form = FilteredContentForm(obj=content)
     return templates.TemplateResponse(
@@ -612,6 +622,7 @@ async def admin_edit_filtered_submit(
         db.query(FilteredContent).filter(FilteredContent.id == content_id).first()
     )
     if not content:
+        logger.warning(f"FilteredContent not found: content_id={content_id}")
         raise NotFoundError("콘텐츠를 찾을 수 없습니다.")
     content.filter_result = filter_result
     content.reasoning = reasoning

--- a/app/routers/blog.py
+++ b/app/routers/blog.py
@@ -2,6 +2,9 @@
 
 from fastapi import APIRouter, Request, Depends
 from app.exceptions import NotFoundError
+import logging
+
+logger = logging.getLogger(__name__)
 from fastapi.responses import HTMLResponse
 from sqlalchemy.orm import Session
 from urllib.parse import unquote
@@ -59,6 +62,7 @@ async def blog_category(
         # 디버깅: 존재하는 카테고리들 출력
         existing_categories = db.query(Category).all()
         print(f"📋 존재하는 카테고리들: {[c.slug for c in existing_categories]}")
+        logger.warning(f"Category not found: slug={category_slug}")
         raise NotFoundError("카테고리를 찾을 수 없습니다.")
     
     per_page = 6
@@ -111,6 +115,7 @@ async def blog_detail(
         ).first()
     
     if not post:
+        logger.warning(f"Post not found: slug={slug}")
         raise NotFoundError("포스트를 찾을 수 없습니다.")
     
     # 조회수 증가

--- a/app/routers/saju.py
+++ b/app/routers/saju.py
@@ -761,6 +761,9 @@ async def saju_page1_submit(
 
     # 입력값 검증
     if not gender or not birth_year or not birth_month or not birth_day:
+        logger.warning(
+            f"Missing required fields: gender={gender}, year={birth_year}, month={birth_month}, day={birth_day}"
+        )
         raise BadRequestError("필수 입력값이 누락되었습니다.")
 
     # 출생 시간 처리 (refactored to match latest logic)
@@ -905,6 +908,7 @@ async def api_saju_ai_analysis(request: Request, db: Session = Depends(get_db)):
     
     saju_key = request.session.get("saju_key")
     if not saju_key:
+        logger.warning("Saju key missing in session")
         raise BadRequestError("사주 정보가 없습니다.")
     
     # 🔄 글로벌 캐시 확인
@@ -1180,6 +1184,7 @@ async def api_saju_ai_analysis_2(request: Request, db: Session = Depends(get_db)
  # === DB 캐시 확인 ===
     saju_key = request.session.get("saju_key")
     if not saju_key:
+        logger.warning("Saju key missing in session")
         raise BadRequestError("사주 정보가 없습니다.")
 
 


### PR DESCRIPTION
## Summary
- inject logging into blog and admin routers
- log warning for missing fields or IDs before raising exceptions in routers
- add context-aware logs in order and saju routers

## Testing
- `pytest -q tests/test_order_api.py`
- `pytest -q` *(fails: OpenAI key missing and DB connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_685f4a655220832bacefc8b96e027669