### PR TITLE
Add FastAPI fixtures and error handling tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,41 @@
+import os
+import types
+import pytest
+from fastapi.testclient import TestClient
+
+# Ensure environment variables so importing app works
+os.environ.setdefault("OPENAI_API_KEY", "test")
+os.environ.setdefault("DATABASE_URL", "sqlite:///./test.db")
+
+from app.main import app
+from app.database import get_db
+
+class DummySession:
+    def query(self, *args, **kwargs):
+        return self
+
+    def filter(self, *args, **kwargs):
+        return self
+
+    def first(self):
+        return None
+
+    def commit(self):
+        pass
+
+    def close(self):
+        pass
+
+def override_get_db():
+    db = DummySession()
+    try:
+        yield db
+    finally:
+        db.close()
+
+@pytest.fixture()
+def client():
+    app.dependency_overrides[get_db] = override_get_db
+    with TestClient(app, raise_server_exceptions=False) as c:
+        yield c
+    app.dependency_overrides.pop(get_db, None)

--- a/tests/test_error_handling.py
+++ b/tests/test_error_handling.py
@@ -1,0 +1,30 @@
+from app.main import app
+
+
+def test_blog_detail_404_html(client):
+    res = client.get('/blog/nonexistent-post', headers={'accept': 'text/html'})
+    assert res.status_code == 404
+    assert '페이지를 찾을 수 없습니다' in res.text
+
+def test_generic_exception_html(client):
+    async def trigger_error():
+        raise Exception('boom')
+    app.add_api_route('/trigger-error', trigger_error)
+    try:
+        res = client.get('/trigger-error', headers={'accept': 'text/html'})
+        assert res.status_code == 500
+        assert '서버 오류가 발생했습니다' in res.text
+    finally:
+        app.router.routes.pop()
+
+def test_generic_exception_json(client):
+    async def trigger_error():
+        raise Exception('boom')
+    app.add_api_route('/trigger-error', trigger_error)
+    try:
+        res = client.get('/trigger-error', headers={'accept': 'application/json'})
+        assert res.status_code == 500
+        assert res.json()['detail'] == '서버 오류가 발생했습니다.'
+    finally:
+        app.router.routes.pop()
+

--- a/tests/test_order_api.py
+++ b/tests/test_order_api.py
@@ -1,37 +1,9 @@
-import os
 import types
 import pytest
-from fastapi.testclient import TestClient
-
-# Set dummy API key so importing app doesn't fail
-os.environ.setdefault("OPENAI_API_KEY", "test")
-os.environ.setdefault("DATABASE_URL", "sqlite:///./test.db")
 
 from app.main import app
 from app.dependencies import get_current_user
-from app.database import get_db
 from app.exceptions import UnauthorizedError
-
-
-class DummySession:
-    def query(self, *args, **kwargs):
-        return self
-
-    def filter(self, *args, **kwargs):
-        return self
-
-    def first(self):
-        return None
-
-    def close(self):
-        pass
-
-def override_get_db():
-    db = DummySession()
-    try:
-        yield db
-    finally:
-        db.close()
 
 
 def override_unauthenticated():
@@ -42,21 +14,16 @@ def override_user():
     return types.SimpleNamespace(id=1)
 
 
-app.dependency_overrides[get_db] = override_get_db
-
-
-def test_order_create_unauthenticated():
+def test_order_create_unauthenticated(client):
     app.dependency_overrides[get_current_user] = override_unauthenticated
-    client = TestClient(app)
     res = client.post("/order/create", json={"saju_key": "test"})
     assert res.status_code == 401
     assert res.json()["detail"] == "로그인이 필요합니다."
     app.dependency_overrides.pop(get_current_user)
 
 
-def test_order_status_not_found():
+def test_order_status_not_found(client):
     app.dependency_overrides[get_current_user] = override_user
-    client = TestClient(app)
     res = client.get("/order/status/1")
     assert res.status_code == 404
     assert res.json()["detail"] == "주문을 찾을 수 없습니다."


### PR DESCRIPTION
## Summary
- provide reusable FastAPI `TestClient` fixture
- use fixture in existing order API tests
- add tests for blog 404 and generic error handling

## Testing
- `pytest -q tests`

------
https://chatgpt.com/codex/tasks/task_e_685f5150f010832bbb41cd494ec4d55a